### PR TITLE
Quote string to be signed before going in shell

### DIFF
--- a/lastfm.lisp
+++ b/lastfm.lisp
@@ -217,7 +217,7 @@ them, and with the shared secret appended to the end of this string."
   (subseq
    (with-output-to-string (s)
      (run-program
-      (format nil "echo -n ~a | md5sum" str)
+      (format nil "echo -n \"~a\" | md5sum" str)
       :output s))
    0 32))
 


### PR DESCRIPTION
Tracks with characters like `(` were throwing errors while scrobbling (sign function). Quoting with " should fix this. I believe a more robust solution would be to not create strings to send to shell but use something like [this](https://github.com/pmai/md5) or maybe something from inferior-shell.