### PR TITLE
Add :utf-8 encoding for drakma requests

### DIFF
--- a/lastfm.lisp
+++ b/lastfm.lisp
@@ -176,6 +176,7 @@ them, and with the shared secret appended to the end of this string."
   "Make the request through the Last.fm API"
   (let ((resp (http-request *base-url*
                              :method :post
+                             :external-format-out :utf-8
                              :parameters
                              (param-value-list method param-values))))
     ;; Sometimes, the response is nil. Try again.


### PR DESCRIPTION
This allows entities with non-latin characters (bunch of eastern tracks) to be scrobbled.

I have only tried scrobbling api but don't think it should have any negative impact on others.